### PR TITLE
Fix: Add early check for macOS incompatibility with flashinfer/triton

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ pip install -e .
 
 ```
 
+### Platform Compatibility
+
+Tokasaurus uses `flashinfer`, which depends on [Triton](https://github.com/triton-lang/triton).
+
+**Triton is not supported on macOS** — there are no compatible wheels or source build paths, and it requires CUDA (not available on macOS).
+
+If you're running Tokasaurus on macOS, you'll encounter an error like: ModuleNotFoundError: No module named ‘triton’
+
+We recommend running Tokasaurus in a **Linux environment with a CUDA-compatible GPU** for full functionality.
+
+
 ## Quickstart
 
 Once installed, you can launch the engine with:

--- a/tokasaurus/entry.py
+++ b/tokasaurus/entry.py
@@ -1,3 +1,6 @@
+from tokasaurus.environment import assert_flashinfer_supported
+
+assert_flashinfer_supported()
 from contextlib import contextmanager
 
 import pydra

--- a/tokasaurus/environment.py
+++ b/tokasaurus/environment.py
@@ -1,0 +1,21 @@
+import platform
+
+
+def is_flashinfer_supported() -> bool:
+    """
+    Returns True if flashinfer (and Triton) are likely usable on this platform.
+    Currently, Triton does not support macOS.
+    """
+    return platform.system() != "Darwin"
+
+
+def assert_flashinfer_supported():
+    """
+    Raises a RuntimeError with a clear message if the current platform is not supported by flashinfer.
+    """
+    if not is_flashinfer_supported():
+        raise RuntimeError(
+            "Tokasaurus currently depends on flashinfer, which in turn requires 'triton'.\n"
+            "However, 'triton' is not supported on macOS.\n"
+            "Please run Tokasaurus in a Linux environment with a supported GPU."
+        )


### PR DESCRIPTION
This PR adds an early runtime check to catch macOS incompatibility due to `flashinfer`'s dependency on `triton`, which is not supported on macOS.

This prevents obscure crashes (`ModuleNotFoundError: triton`) and replaces them with a clear, actionable error message:

RuntimeError: Tokasaurus currently depends on flashinfer, which in turn requires ‘triton’.
However, ‘triton’ is not supported on macOS.
Please run Tokasaurus in a Linux environment with a supported GPU.

### Implementation

- Introduced `assert_flashinfer_supported()` in `tokasaurus/environment.py`
- Called it at the top of `entry.py` before any indirect flashinfer imports
- Updated README with a "Platform Compatibility" note

This improves the developer experience for macOS users without affecting behavior on Linux.


Output:

```bash

(tokasaurus) ╭─lxyuan@devbox ~/personal_works/tokasaurus  ‹fix/macos-triton-guard›
╰─➤  toka model=meta-llama/Llama-3.2-1B-Instruct
Traceback (most recent call last):
  File "/Users/yuanlikxun/personal_works/tokasaurus/.venv/bin/toka", line 5, in <module>
    from tokasaurus.entry import main
  File "/Users/yuanlikxun/personal_works/tokasaurus/tokasaurus/entry.py", line 3, in <module>
    assert_flashinfer_supported()
  File "/Users/yuanlikxun/personal_works/tokasaurus/tokasaurus/environment.py", line 17, in assert_flashinfer_supported
    raise RuntimeError(
RuntimeError: Tokasaurus currently depends on flashinfer, which in turn requires 'triton'.
However, 'triton' is not supported on macOS.
Please run Tokasaurus in a Linux environment with a supported GPU.
```