### PR TITLE
Return actual model from v1/models

### DIFF
--- a/tokasaurus/server/endpoints.py
+++ b/tokasaurus/server/endpoints.py
@@ -215,15 +215,17 @@ async def retrieve_batch(
 
 @app.get("/v1/models")
 async def list_models():
+    state: ServerState = app.state.state_bundle
+
     return SyncPage(
         object="list",
         data=[
             Model(
-                id="default",
+                id=state.config.model,
                 created=nowstamp(),
                 object="model",
                 owned_by="tokasaurus",
-            )
+            ),
         ],
     )
 


### PR DESCRIPTION
Actually return the model name when calling `v1/models`. Useful for sanity checking in my experiments that I ran things with the correct model. 

```
curl -X GET http://0.0.0.0:10210/v1/models
```

Note: I got rid of the entry for "default" -- not sure if there's any need for it