### PR TITLE
Add support for a synchronous batch endpoint

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,11 +1,13 @@
 import json
 import os
+import pickle
 import shlex
 import tempfile
 import time
 
 import pydra
 import pytest
+import requests
 import torch
 import torch.multiprocessing as mp
 from openai import OpenAI
@@ -277,8 +279,6 @@ def test_batch_chat_completions(client: OpenAI):
 
 
 def test_synchronous_batch_completions(client: OpenAI):
-    import requests
-    
     # Test synchronous batch completions endpoint
     batch_request = {
         "requests": [
@@ -302,26 +302,24 @@ def test_synchronous_batch_completions(client: OpenAI):
             },
         ]
     }
-    
-    # Make request to our custom endpoint
-    url = str(client.base_url).split("/v1")[0] + "/batch/chat/completions"  # update the path
 
-    response = requests.post(
-        url,
-        json=batch_request,
-        headers={"Authorization": f"Bearer {client.api_key}"}
-    )
-    
+    # Make request to our custom endpoint
+    url = (
+        str(client.base_url).split("/v1")[0] + "/custom/synchronous-batch-completions"
+    )  # update the path
+
+    response = requests.post(url, json=batch_request)
+
     assert response.status_code == 200
-    import pickle
+
     result = pickle.loads(response.content)
-        
+
     # Verify response structure
     assert len(result) == 3
-    
+
     # Verify each completion
     completions = result
-    assert completions[0]["choices"][0].message.content == "hello"
-    assert completions[1]["choices"][0].message.content == "world"
-    assert completions[2]["choices"][0].message.content == "test"
-    
+
+    assert completions[0].choices[0].message.content == "hello"
+    assert completions[1].choices[0].message.content == "world"
+    assert completions[2].choices[0].message.content == "test"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -276,7 +276,7 @@ def test_batch_chat_completions(client: OpenAI):
     assert custom_id_to_parsed["request-2"].choices[0].message.content == "howdy"
 
 
-def test_batch_completions_endpoint(client: OpenAI):
+def test_synchronous_batch_completions(client: OpenAI):
     import requests
     
     # Test synchronous batch completions endpoint
@@ -313,19 +313,15 @@ def test_batch_completions_endpoint(client: OpenAI):
     )
     
     assert response.status_code == 200
-    result = response.json()
-    
+    import pickle
+    result = pickle.loads(response.content)
+        
     # Verify response structure
-    assert "completions" in result
-    assert len(result["completions"]) == 3
+    assert len(result) == 3
     
     # Verify each completion
-    completions = result["completions"]
-    assert completions[0]["choices"][0]["message"]["content"] == "hello"
-    assert completions[1]["choices"][0]["message"]["content"] == "world"
-    assert completions[2]["choices"][0]["message"]["content"] == "test"
+    completions = result
+    assert completions[0]["choices"][0].message.content == "hello"
+    assert completions[1]["choices"][0].message.content == "world"
+    assert completions[2]["choices"][0].message.content == "test"
     
-    # Verify results are in correct order
-    expected_words = ["hello", "world", "test"]
-    for i, completion in enumerate(completions):
-        assert completion["choices"][0]["message"]["content"] == expected_words[i]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -274,3 +274,56 @@ def test_batch_chat_completions(client: OpenAI):
 
     assert custom_id_to_parsed["request-1"].choices[0].message.content == "hello"
     assert custom_id_to_parsed["request-2"].choices[0].message.content == "howdy"
+
+
+def test_batch_completions_endpoint(client: OpenAI):
+    import requests
+    
+    # Test synchronous batch completions endpoint
+    batch_request = {
+        "requests": [
+            {
+                "model": MODEL,
+                "messages": make_messages("hello"),
+                "max_tokens": 20,
+                "temperature": 0.0,
+            },
+            {
+                "model": MODEL,
+                "messages": make_messages("world"),
+                "max_tokens": 20,
+                "temperature": 0.0,
+            },
+            {
+                "model": MODEL,
+                "messages": make_messages("test"),
+                "max_tokens": 20,
+                "temperature": 0.0,
+            },
+        ]
+    }
+    
+    # Make request to our custom endpoint
+    response = requests.post(
+        f"{client.base_url}batch/chat/completions",
+        json=batch_request,
+        headers={"Authorization": f"Bearer {client.api_key}"}
+    )
+    
+    assert response.status_code == 200
+    result = response.json()
+    
+    # Verify response structure
+    assert "completions" in result
+    assert len(result["completions"]) == 3
+    
+    # Verify each completion
+    completions = result["completions"]
+    assert completions[0]["choices"][0]["message"]["content"] == "hello"
+    assert completions[1]["choices"][0]["message"]["content"] == "world"
+    assert completions[2]["choices"][0]["message"]["content"] == "test"
+    
+    # Verify results are in correct order
+    expected_words = ["hello", "world", "test"]
+    for i, completion in enumerate(completions):
+        assert completion["choices"][0]["message"]["content"] == expected_words[i]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -304,8 +304,10 @@ def test_batch_completions_endpoint(client: OpenAI):
     }
     
     # Make request to our custom endpoint
+    url = str(client.base_url).split("/v1")[0] + "/batch/chat/completions"  # update the path
+
     response = requests.post(
-        f"{client.base_url}batch/chat/completions",
+        url,
         json=batch_request,
         headers={"Authorization": f"Bearer {client.api_key}"}
     )

--- a/tokasaurus/server/endpoints.py
+++ b/tokasaurus/server/endpoints.py
@@ -76,24 +76,6 @@ async def oai_chat_completions(request: ChatCompletionRequest, raw_request: Requ
     return process_chat_completions_output(state, request, req, out)
 
 
-@app.post("/v1/batch/chat/completions")
-@with_cancellation
-async def oai_batch_completions(request: BatchCompletionsRequest, raw_request: Request):
-    state: ServerState = app.state.state_bundle
-    
-    async def generate_and_process(req: ChatCompletionRequest):
-        internal_req, output = await generate_output(state, req)
-        return process_chat_completions_output(state, req, internal_req, output)
-    
-    # Create tasks for each request
-    tasks = [asyncio.create_task(generate_and_process(req)) for req in request.requests]
-    
-    # Wait for all tasks to complete and collect results in order
-    results = await asyncio.gather(*tasks)
-    
-    return {"completions": results}
-
-
 @app.post("/v1/files", response_model=FileObject)
 async def upload_file(
     file: UploadFile,
@@ -247,6 +229,33 @@ async def list_models():
             ),
         ],
     )
+
+### ------------------------------------------------------------
+### BEGIN NON-OAI ENDPOINTS
+### ------------------------------------------------------------
+
+@app.post("/batch/chat/completions")
+@with_cancellation
+async def oai_batch_completions(request: BatchCompletionsRequest, raw_request: Request):
+    state: ServerState = app.state.state_bundle
+    
+    async def generate_and_process(req: ChatCompletionRequest):
+        internal_req, output = await generate_output(state, req)
+        return process_chat_completions_output(state, req, internal_req, output)
+    
+    # Create tasks for each request
+    tasks = [asyncio.create_task(generate_and_process(req)) for req in request.requests]
+    
+    # Wait for all tasks to complete and collect results in order
+    results = await asyncio.gather(*tasks)
+    
+    return {"completions": results}
+
+### ------------------------------------------------------------
+### END NON-OAI ENDPOINTS
+### ------------------------------------------------------------
+
+
 
 
 def start_server(

--- a/tokasaurus/server/endpoints.py
+++ b/tokasaurus/server/endpoints.py
@@ -236,7 +236,7 @@ async def list_models():
 
 @app.post("/batch/chat/completions")
 @with_cancellation
-async def oai_batch_completions(request: BatchCompletionsRequest, raw_request: Request):
+async def synchronous_batch_completions(request: BatchCompletionsRequest, raw_request: Request):
     state: ServerState = app.state.state_bundle
     
     async def generate_and_process(req: ChatCompletionRequest):

--- a/tokasaurus/server/endpoints.py
+++ b/tokasaurus/server/endpoints.py
@@ -1,5 +1,7 @@
 import asyncio
 from contextlib import asynccontextmanager
+import pickle
+import time
 from uuid import uuid4
 
 import uvicorn
@@ -238,7 +240,7 @@ async def list_models():
 @with_cancellation
 async def synchronous_batch_completions(request: BatchCompletionsRequest, raw_request: Request):
     state: ServerState = app.state.state_bundle
-    
+    t0 = time.time()
     async def generate_and_process(req: ChatCompletionRequest):
         internal_req, output = await generate_output(state, req)
         return process_chat_completions_output(state, req, internal_req, output)
@@ -248,8 +250,17 @@ async def synchronous_batch_completions(request: BatchCompletionsRequest, raw_re
     
     # Wait for all tasks to complete and collect results in order
     results = await asyncio.gather(*tasks)
+    t1 = time.time()
+    print(f"synchronous_batch_completions took {t1 - t0} seconds")
+
+    # return {"completions": results}
+
+    pickled_content = pickle.dumps(results)
+    return Response(
+        content=pickled_content, media_type="application/octet-stream"
+    )
     
-    return {"completions": results}
+    # return {"completions": pickle.dumps(results)}
 
 ### ------------------------------------------------------------
 ### END NON-OAI ENDPOINTS

--- a/tokasaurus/server/endpoints.py
+++ b/tokasaurus/server/endpoints.py
@@ -253,15 +253,11 @@ async def synchronous_batch_completions(request: BatchCompletionsRequest, raw_re
     t1 = time.time()
     print(f"synchronous_batch_completions took {t1 - t0} seconds")
 
-    # return {"completions": results}
-
     pickled_content = pickle.dumps(results)
     return Response(
         content=pickled_content, media_type="application/octet-stream"
     )
     
-    # return {"completions": pickle.dumps(results)}
-
 ### ------------------------------------------------------------
 ### END NON-OAI ENDPOINTS
 ### ------------------------------------------------------------

--- a/tokasaurus/server/types.py
+++ b/tokasaurus/server/types.py
@@ -126,7 +126,6 @@ class BatchCompletionsRequest(BaseModel):
     requests: list[ChatCompletionRequest] = Field(
         description="List of chat completion requests to process"
     )
-    metadata: Optional[dict[str, str]] = Field(default=None)
 
 
 @dataclass

--- a/tokasaurus/server/types.py
+++ b/tokasaurus/server/types.py
@@ -89,7 +89,6 @@ class ChatCompletionRequest(BaseModel):
     user: Optional[str] = None
     metadata: Optional[dict] = None
 
-
     # extra fields ---
 
     # needed for sglang benchmarking script
@@ -120,7 +119,7 @@ class BatchCreationRequest(BaseModel):
     metadata: Optional[dict[str, str]] = Field(default=None)
 
 
-class BatchCompletionsRequest(BaseModel):
+class SynchronousBatchCompletionsRequest(BaseModel):
     """Request model for synchronous batch completions"""
 
     requests: list[ChatCompletionRequest] = Field(

--- a/tokasaurus/server/types.py
+++ b/tokasaurus/server/types.py
@@ -120,6 +120,15 @@ class BatchCreationRequest(BaseModel):
     metadata: Optional[dict[str, str]] = Field(default=None)
 
 
+class BatchCompletionsRequest(BaseModel):
+    """Request model for synchronous batch completions"""
+
+    requests: list[ChatCompletionRequest] = Field(
+        description="List of chat completion requests to process"
+    )
+    metadata: Optional[dict[str, str]] = Field(default=None)
+
+
 @dataclass
 class RequestOutput:
     id: str

--- a/tokasaurus/server/utils.py
+++ b/tokasaurus/server/utils.py
@@ -3,6 +3,7 @@ import base64
 import functools
 import json
 from dataclasses import dataclass, field
+import time
 from uuid import uuid4
 
 import numpy as np
@@ -686,7 +687,9 @@ def make_completions_fingerprint(
     obj["packed_topk_indices"] = packed_topk_indices
     obj["packed_topk_logprobs"] = packed_topk_logprobs
 
-    return json.dumps(obj)
+    out = json.dumps(obj)
+
+    return out
 
 
 def process_chat_completions_output(
@@ -723,7 +726,7 @@ def process_chat_completions_output(
         )
         choices.append(choice)
 
-    return ChatCompletion(
+    return dict(
         id=request.id,
         model=crequest.model,
         usage=make_usage_info(request, output),

--- a/tokasaurus/server/utils.py
+++ b/tokasaurus/server/utils.py
@@ -3,7 +3,6 @@ import base64
 import functools
 import json
 from dataclasses import dataclass, field
-import time
 from uuid import uuid4
 
 import numpy as np
@@ -726,7 +725,7 @@ def process_chat_completions_output(
         )
         choices.append(choice)
 
-    return dict(
+    return ChatCompletion(
         id=request.id,
         model=crequest.model,
         usage=make_usage_info(request, output),


### PR DESCRIPTION
 - useful for using with modal, where you can't ensure you're hitting the same replica
 - also I was running jobs with like 8k separate concurrent requests, and something couldn't handle it. this gets around needing to send so many independent requests. 